### PR TITLE
Relaxes gem dependencies

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-ruby 2.5.1
+ruby 2.7.4
 nodejs 8.11.3

--- a/lib/neat.rb
+++ b/lib/neat.rb
@@ -1,12 +1,15 @@
-require "sass"
 require "neat/generator"
 
 module Neat
-  if defined?(Rails::Engine)
+  if defined?(Rails) && defined?(Rails::Engine)
     class Engine < ::Rails::Engine
       config.assets.paths << File.expand_path("../core", __dir__)
     end
   else
-    Sass.load_paths << File.expand_path("../core", __dir__)
+    begin
+      require "sass"
+      Sass.load_paths << File.expand_path("../core", __dir__)
+    rescue LoadError
+    end
   end
 end

--- a/neat.gemspec
+++ b/neat.gemspec
@@ -7,7 +7,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec"
   s.add_development_dependency "scss_lint", "~> 0.44"
-  s.add_runtime_dependency "sass", "~> 3.4"
   s.add_runtime_dependency "thor", "~> 0.19"
   s.authors = [
     "Joel Oliveira",

--- a/neat.gemspec
+++ b/neat.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec"
   s.add_development_dependency "scss_lint", "~> 0.44"
-  s.add_runtime_dependency "thor", "~> 0.19"
+  s.add_runtime_dependency "thor", ">= 0.19"
   s.authors = [
     "Joel Oliveira",
     "Joshua Ogle",


### PR DESCRIPTION
There are two changes here:
- I cherry-picked a commit from the v4 line that removes the dependency on `sass` (which was been deprecated for ages).
- I relaxed the dependency on `thor` so that it will accept more recent versions. I don't actually know if the thor-based generator in this gem will work with the later versions, because the specs don't seem to test it, but I also think that we (Careport) don't use it.